### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/app/modules/filepond/filepond.component.ts
+++ b/src/app/modules/filepond/filepond.component.ts
@@ -131,7 +131,7 @@ export class FilePondComponent implements AfterViewInit, OnChanges, OnDestroy {
     };
     outputs.forEach((event) => {
       this.root.nativeElement.addEventListener(
-        `FilePond:${event.substr(2)}`,
+        `FilePond:${event.slice(2)}`,
         this.handleEvent
       );
     });
@@ -197,7 +197,7 @@ export class FilePondComponent implements AfterViewInit, OnChanges, OnDestroy {
 
     outputs.forEach((event) => {
       this.root.nativeElement.removeEventListener(
-        `FilePond:${event.substr(2)}`,
+        `FilePond:${event.slice(2)}`,
         this.handleEvent
       );
     });


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.